### PR TITLE
Fix course/id page crashing

### DIFF
--- a/app/views/course/show.html
+++ b/app/views/course/show.html
@@ -22,7 +22,7 @@
     </p>
   {% endif %}
 
-  {{course_show.course_show(base_path, course, player, games_played, latest_game, avg_score, par, high_scores, chrono_high_scores, chrono_high_scores_player, score_distribution)}}
+  {{course_show.course_show(base_path, course, player, games_played, latest_game, avg_score, par, high_scores, high_scores_by_user, chrono_high_scores, chrono_high_scores_player, score_distribution)}}
 
 {% endblock %}
 


### PR DESCRIPTION
This fix crashing on GET endpoint `course/:id` by giving right parameters to course_show function.