### PR TITLE
Fix game adding mobile gui error

### DIFF
--- a/assets/js/mobilegui/services.js
+++ b/assets/js/mobilegui/services.js
@@ -205,6 +205,7 @@ function toPar(playerid) {
 }
 
 function createForm(url, data) {
+    $('form').remove();
     var form = document.createElement('form');
     form.method = 'post';
     form.action = url;


### PR DESCRIPTION
This fix following error in mobile gui game addition.

`PHP Warning:  Unknown: Input variables exceeded 1000. To increase the limit change max_input_vars in php.ini. in Unknown on line 0, referer: https://dromedaari.kapsi.fi/disc-golf-stats/game/mobile/800`

It was caused by client sending over 1000 input variables per request  to server when in each  new`POST` request new variables were appended to same list with old variables. After some played holes client was sending over 1000 input variables to server.

In this fix old game forms are removed before creating new form.

The same error can still occur if game has too many holes and players. Amount of input variables can be calculated with simple function

amount of variable = 3 + 2 *  (amount of holes + amount of players)