### PR TITLE
Do not show aces as as birdie in par 2 holes

### DIFF
--- a/app/models/Course.php
+++ b/app/models/Course.php
@@ -444,7 +444,7 @@
                 CASE WHEN score.stroke = 1 THEN 1 END AS hole_in_one,
                 CASE WHEN hole.par - score.stroke - score.ob = 2 AND score.stroke != 1 THEN 1 END AS eagle,
                 CASE WHEN hole.par - score.stroke - score.ob = 1 AND score.stroke != 1 THEN 1 END AS birdie,
-                CASE WHEN hole.par - score.stroke - score.ob = 0 THEN 1 END AS par,
+                CASE WHEN hole.par - score.stroke - score.ob = 0 AND score.stroke != 1 THEN 1 END AS par,
                 CASE WHEN hole.par - score.stroke - score.ob = -1 THEN 1 END AS bogey,
                 CASE WHEN hole.par - score.stroke - score.ob < -1 THEN 1 END AS over_bogey
                 FROM score

--- a/app/models/Course.php
+++ b/app/models/Course.php
@@ -443,7 +443,7 @@
                 SELECT hole.hole_num,
                 CASE WHEN score.stroke = 1 THEN 1 END AS hole_in_one,
                 CASE WHEN hole.par - score.stroke - score.ob = 2 AND score.stroke != 1 THEN 1 END AS eagle,
-                CASE WHEN hole.par - score.stroke - score.ob = 1 THEN 1 END AS birdie,
+                CASE WHEN hole.par - score.stroke - score.ob = 1 AND score.stroke != 1 THEN 1 END AS birdie,
                 CASE WHEN hole.par - score.stroke - score.ob = 0 THEN 1 END AS par,
                 CASE WHEN hole.par - score.stroke - score.ob = -1 THEN 1 END AS bogey,
                 CASE WHEN hole.par - score.stroke - score.ob < -1 THEN 1 END AS over_bogey

--- a/app/models/Course.php
+++ b/app/models/Course.php
@@ -441,10 +441,10 @@
               COUNT(over_bogey) AS over_bogey
               FROM (
                 SELECT hole.hole_num,
-                CASE WHEN score.stroke = 1 THEN 1 END AS hole_in_one,
+                CASE WHEN score.stroke = 1 AND hole.par != 1 THEN 1 END AS hole_in_one,
                 CASE WHEN hole.par - score.stroke - score.ob = 2 AND score.stroke != 1 THEN 1 END AS eagle,
                 CASE WHEN hole.par - score.stroke - score.ob = 1 AND score.stroke != 1 THEN 1 END AS birdie,
-                CASE WHEN hole.par - score.stroke - score.ob = 0 AND score.stroke != 1 THEN 1 END AS par,
+                CASE WHEN hole.par - score.stroke - score.ob = 0 THEN 1 END AS par,
                 CASE WHEN hole.par - score.stroke - score.ob = -1 THEN 1 END AS bogey,
                 CASE WHEN hole.par - score.stroke - score.ob < -1 THEN 1 END AS over_bogey
                 FROM score


### PR DESCRIPTION
This fixes bug in score distribution chart. Hole in ones are not showed as birdies in par 2 holes and as pars in par 1 holes.